### PR TITLE
Values param for env.from(values) uses process.env typings

### DIFF
--- a/env-var.d.ts
+++ b/env-var.d.ts
@@ -219,7 +219,7 @@ interface IEnv {
    * Returns a new env-var instance, where the given object is used for the environment variable mapping.
    * Use this when writing unit tests or in environments outside node.js.
    */
-  from(values: {[varName: string]: string}): IEnv;
+  from(values: NodeJS.ProcessEnv): IEnv;
 
   /**
    * This is the error type used to represent error returned by this module.

--- a/test/index.ts
+++ b/test/index.ts
@@ -78,6 +78,11 @@ function test () {
 
   assert.equal(env.get('URL_STRING').asUrlObject(), url.parse(process.env.URL_STRING))
   assert.equal(env.get('URL_STRING').asUrlString(), 'http://google.com')
+
+  // FROM
+  const newEnv = env.from(process.env)
+  assert.equal(newEnv.get('STRING').required().asString(), process.env.STRING)
+  assert.equal(newEnv.get('SOME_STRING').asString(), process.env.STRING)
 }
 
 export default test;


### PR DESCRIPTION
## Issue

Using the `from(values)` method will throw a typescript syntax error when passing in `process.env`.

## Solution 

`values` param uses the `NodeJs.ProcessEnv` typing.
See: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/bf90e32d0c2068ae2d250eea528f1713a298ee3d/types/node/globals.d.ts#L704