### PR TITLE
[#71] Implement custom accessors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
   - "10"
   - "9"
   - "8"
-  - "7"
-  - "6"
 
 after_success:
   - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -315,8 +315,8 @@ let validEmail = env.get('ADMIN').checkEmail()
 The accessor function may accept additional arguments if desired; these must be
 provided explicitly when the accessor is invoked.
 
-For example, we can modify the `checkEmail()` accessor so that it optionally
-verifies the domain of the email address:
+For example, we can modify the `checkEmail()` accessor from above so that it
+optionally verifies the domain of the email address:
 ```js
 const env = require('env-var')
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ const apiUrl = mockedEnv.get('API_BASE_URL').asUrlString()
 ```
 
 #### extraAccessors
-When calling `from()` you can also pass an optional argument containing
+When calling `from()` you can also pass an optional parameter containing
 additional accessors that will be attached to any variables gotten by that
 env-var instance.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 </div>
 
-Verification, sanatization, and type coercion for environment variables in
+Verification, sanitization, and type coercion for environment variables in
 Node.js. Particularly useful in TypeScript environments.
 
 ## Install
@@ -140,10 +140,8 @@ When calling `from()` you can also pass an optional argument containing
 additional accessors that will be attached to any variables gotten by that
 env-var instance.
 
-Accessor functions must accept at least two arguments:
+Accessor functions must accept at least one argument:
 
-- `{Function} raiseError`: If the accessor fails to process a value, it must
-  call this function instead of throwing an exception.
 - `{*} value`: The value that the accessor should process.
 
 **Important:** Do not assume that `value` is a string!
@@ -158,12 +156,12 @@ process.env.ADMIN = 'admin@example.com'
 // Add an accessor named 'checkEmail' that verifies that the value is a
 // valid-looking email address.
 const env = from(process.env, {
-  checkEmail: (raiseError, value) => {
+  checkEmail: (value) => {
     const split = String(value).split('@')
 
     // Validating email addresses is hard.
     if (split.length !== 2) {
-      raiseError('must contain exactly one "@"')
+      throw new Error('must contain exactly one "@"')
     }
 
     return value
@@ -190,20 +188,20 @@ process.env.ADMIN = 'admin@example.com'
 // Add an accessor named 'checkEmail' that verifies that the value is a
 // valid-looking email address.
 //
-// Note that the accessor function also accepts an optional third
+// Note that the accessor function also accepts an optional second
 // parameter `requiredDomain` which can be provided when the accessor is
 // invoked (see below).
 const env = from(process.env, {
-  checkEmail: (raiseError, value, requiredDomain) => {
+  checkEmail: (value, requiredDomain) => {
     const split = String(value).split('@')
 
     // Validating email addresses is hard.
     if (split.length !== 2) {
-      raiseError('must contain exactly one "@"')
+      throw new Error('must contain exactly one "@"')
     }
 
     if (requiredDomain && (split[1] !== requiredDomain)) {
-      raiseError(`must end with @${requiredDomain}`)
+      throw new Error(`must end with @${requiredDomain}`)
     }
 
     return value
@@ -214,9 +212,9 @@ const env = from(process.env, {
 // `addAccessor()` above, so now we can call `checkEmail()` like any
 // other accessor.
 //
-// `env-var` will provide the first two arguments for the accessor
-// function (`raiseError` and `value`), but we declared a third argument
-// `requiredDomain`, which we can provide when we invoke the accessor.
+// `env-var` will provide the first argument for the accessor function
+// (`value`), but we declared a second argument `requiredDomain`, which
+// we can provide when we invoke the accessor.
 
 // Calling the accessor without additional parameters accepts an email
 // address with any domain.

--- a/README.md
+++ b/README.md
@@ -167,9 +167,8 @@ const env = from(process.env, {
   }
 })
 
-// We specified 'checkEmail' as the name for the accessor when we called
-// `addAccessor()` above, so now we can call `checkEmail()` like any
-// other accessor.
+// We specified 'checkEmail' as the name for the accessor above, so now
+// we can call `checkEmail()` like any other accessor.
 let validEmail = env.get('ADMIN').checkEmail()
 ```
 
@@ -207,9 +206,8 @@ const env = from(process.env, {
   }
 })
 
-// We specified 'checkEmail' as the name for the accessor when we called
-// `addAccessor()` above, so now we can call `checkEmail()` like any
-// other accessor.
+// We specified 'checkEmail' as the name for the accessor above, so now
+// we can call `checkEmail()` like any other accessor.
 //
 // `env-var` will provide the first argument for the accessor function
 // (`value`), but we declared a second argument `requiredDomain`, which

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ complex to understand as [demonstrated here](https://gist.github.com/evanshortis
       * [asString()](#asstring)
       * [asUrlObject()](#asurlobject)
       * [asUrlString()](#asurlstring)
-  * [addAccessor()](#addaccessorname-accessor)
 
 ### EnvVarError()
 This is the error class used to represent errors raised by this module. Sample

--- a/env-var.js
+++ b/env-var.js
@@ -6,11 +6,11 @@ const variable = require('./lib/variable')
  * Returns an "env-var" instance that reads from the given container of values.
  * By default, we export an instance that reads from process.env
  * @param  {Object} container target container to read values from
+ * @param  {Object} extraAccessors additional accessors to attach to the
+ * resulting object
  * @return {Object} a new module instance
  */
-const from = (container) => {
-  const _extraAccessors = {}
-
+const from = (container, extraAccessors) => {
   return {
     from: from,
 
@@ -19,16 +19,6 @@ const from = (container) => {
      * exceptions and handle them appropriately.
      */
     EnvVarError: require('./lib/env-error'),
-
-    /**
-     * Adds a custom accessor to subsequent variables.
-     *
-     * @param  {String} name Name of the accessor (i.e., function name).
-     * @param  {Function} accessor Accessor function.
-     */
-    addAccessor: (name, accessor) => {
-      _extraAccessors[name] = accessor
-    },
 
     /**
      * Returns a variable instance with helper functions, or process.env
@@ -41,7 +31,7 @@ const from = (container) => {
         return container
       }
 
-      return variable(container, variableName, defaultValue, _extraAccessors)
+      return variable(container, variableName, defaultValue, extraAccessors || {})
     }
   }
 }

--- a/env-var.js
+++ b/env-var.js
@@ -9,14 +9,14 @@ const variable = require('./lib/variable')
  * @return {Object} a new module instance
  */
 const from = (container) => {
-  var _extraAccessors = {}
+  const _extraAccessors = {}
 
   return {
     from: from,
 
     /**
      * This is the Error class used to generate exceptions. Can be used to identify
-     * exceptions and handle them appropriatly.
+     * exceptions and handle them appropriately.
      */
     EnvVarError: require('./lib/env-error'),
 

--- a/env-var.js
+++ b/env-var.js
@@ -9,14 +9,26 @@ const variable = require('./lib/variable')
  * @return {Object} a new module instance
  */
 const from = (container) => {
+  var _extraAccessors = {}
+
   return {
     from: from,
 
     /**
      * This is the Error class used to generate exceptions. Can be used to identify
-     * exceptions adn handle them appropriatly.
+     * exceptions and handle them appropriatly.
      */
     EnvVarError: require('./lib/env-error'),
+
+    /**
+     * Adds a custom accessor to subsequent variables.
+     *
+     * @param  {String} name Name of the accessor (i.e., function name).
+     * @param  {Function} accessor Accessor function.
+     */
+    addAccessor: (name, accessor) => {
+      _extraAccessors[name] = accessor
+    },
 
     /**
      * Returns a variable instance with helper functions, or process.env
@@ -29,7 +41,7 @@ const from = (container) => {
         return container
       }
 
-      return variable(container, variableName, defaultValue)
+      return variable(container, variableName, defaultValue, _extraAccessors)
     }
   }
 }

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -6,9 +6,13 @@ const base64Regex = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-
 /**
  * Returns an Object that contains functions to read and specify the format of
  * the variable you wish to have returned
+ * @param  {Object} container Encapsulated container (e.g., `process.env`).
+ * @param  {String} varName Name of the requested property from `container`.
+ * @param  {*} defValue Default value to return if `varName` is invalid.
+ * @param  {Function[]} extraAccessors Extra accessors to install.
  * @return {Object}
  */
-module.exports = function getVariableAccessors (container, varName, defValue, extraAccessors = {}) {
+module.exports = function getVariableAccessors (container, varName, defValue, extraAccessors) {
   let isBase64 = false
 
   /**

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -8,7 +8,7 @@ const base64Regex = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-
  * the variable you wish to have returned
  * @return {Object}
  */
-module.exports = function getVariableAccessors (container, varName, defValue) {
+module.exports = function getVariableAccessors (container, varName, defValue, extraAccessors = {}) {
   let isBase64 = false
 
   /**
@@ -111,6 +111,11 @@ module.exports = function getVariableAccessors (container, varName, defValue) {
       return accessors
     }
   }
+
+  // Attach extra accessors, if provided.
+  Object.entries(extraAccessors).forEach(([name, accessor]) => {
+    accessors[name] = generateAccessor(accessor)
+  })
 
   return accessors
 }

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -9,7 +9,7 @@ const base64Regex = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-
  * @param  {Object} container Encapsulated container (e.g., `process.env`).
  * @param  {String} varName Name of the requested property from `container`.
  * @param  {*} defValue Default value to return if `varName` is invalid.
- * @param  {Function[]} extraAccessors Extra accessors to install.
+ * @param  {Object} extraAccessors Extra accessors to install.
  * @return {Object}
  */
 module.exports = function getVariableAccessors (container, varName, defValue, extraAccessors) {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "mocha": "~6.2.0",
     "mocha-lcov-reporter": "~1.3.0",
     "nyc": "~14.1.0",
-    "standard": "~13.1.0",
+    "standard": "~14.0.0",
     "typescript": "~3.1.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/evanshortiss/env-var",
   "devDependencies": {
-    "@types/node": "~12.6.0",
+    "@types/node": "~12.7.0",
     "bluebird": "~3.5.1",
     "chai": "~4.2.0",
     "coveralls": "~3.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -548,7 +548,7 @@ describe('env-var', function () {
       expect(fromMod.get('STRING').asString()).to.equal('!dlrow ,olleH')
     })
 
-    it('should not attach accessors to other env instances', function() {
+    it('should not attach accessors to other env instances', function () {
       var otherMod = mod.from({
         STRING: 'Hola, mundo!'
       })

--- a/test/index.js
+++ b/test/index.js
@@ -539,13 +539,26 @@ describe('env-var', function () {
       expect(gotten).not.to.have.property('asWhisper')
     })
 
-    it('allows overriding existing accessors', function () {
+    it('should allow overriding existing accessors', function () {
       fromMod.addAccessor('asString', function (raiseError, value) {
         // https://stackoverflow.com/a/959004
         return value.split('').reverse().join('')
       })
 
       expect(fromMod.get('STRING').asString()).to.equal('!dlrow ,olleH')
+    })
+
+    it('should not attach accessors to other env instances', function() {
+      var otherMod = mod.from({
+        STRING: 'Hola, mundo!'
+      })
+
+      fromMod.addAccessor('asNull', function (raiseError, value) {
+        return null
+      })
+
+      expect(fromMod.get('STRING')).to.have.property('asNull')
+      expect(otherMod.get('STRING')).not.to.have.property('asNull')
     })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -506,4 +506,46 @@ describe('env-var', function () {
       expect(fromMod.get()).to.have.property('A_STRING', 'blah')
     })
   })
+
+  describe('#addAccessor', function() {
+    // Use `from` to avoid polluting global env's namespace.
+    var fromMod
+
+    beforeEach(function() {
+      fromMod = mod.from({
+        STRING: 'Hello, world!'
+      })
+    })
+
+    it('should add custom accessors to subsequent gotten values', function() {
+      fromMod.addAccessor('asShout', function(raiseError, value) {
+        return value.toUpperCase()
+      })
+
+      var gotten = fromMod.get('STRING')
+
+      expect(gotten).to.have.property('asShout')
+      expect(gotten.asShout()).to.equal('HELLO, WORLD!')
+    })
+
+    it('should not affect previously-gotten values', function() {
+      // Get the value before adding custom accessor.
+      var gotten = fromMod.get('STRING')
+
+      fromMod.addAccessor('asWhisper', function(raiseError, value) {
+        return value.toLowerCase()
+      })
+
+      expect(gotten).not.to.have.property('asWhisper')
+    })
+
+    it('allows overriding existing accessors', function() {
+      fromMod.addAccessor('asString', function(raiseError, value) {
+        // https://stackoverflow.com/a/959004
+        return value.split('').reverse().join('')
+      })
+
+      expect(fromMod.get('STRING').asString()).to.equal('!dlrow ,olleH')
+    })
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -507,18 +507,18 @@ describe('env-var', function () {
     })
   })
 
-  describe('#addAccessor', function() {
+  describe('#addAccessor', function () {
     // Use `from` to avoid polluting global env's namespace.
     var fromMod
 
-    beforeEach(function() {
+    beforeEach(function () {
       fromMod = mod.from({
         STRING: 'Hello, world!'
       })
     })
 
-    it('should add custom accessors to subsequent gotten values', function() {
-      fromMod.addAccessor('asShout', function(raiseError, value) {
+    it('should add custom accessors to subsequent gotten values', function () {
+      fromMod.addAccessor('asShout', function (raiseError, value) {
         return value.toUpperCase()
       })
 
@@ -528,19 +528,19 @@ describe('env-var', function () {
       expect(gotten.asShout()).to.equal('HELLO, WORLD!')
     })
 
-    it('should not affect previously-gotten values', function() {
+    it('should not affect previously-gotten values', function () {
       // Get the value before adding custom accessor.
       var gotten = fromMod.get('STRING')
 
-      fromMod.addAccessor('asWhisper', function(raiseError, value) {
+      fromMod.addAccessor('asWhisper', function (raiseError, value) {
         return value.toLowerCase()
       })
 
       expect(gotten).not.to.have.property('asWhisper')
     })
 
-    it('allows overriding existing accessors', function() {
-      fromMod.addAccessor('asString', function(raiseError, value) {
+    it('allows overriding existing accessors', function () {
+      fromMod.addAccessor('asString', function (raiseError, value) {
         // https://stackoverflow.com/a/959004
         return value.split('').reverse().join('')
       })

--- a/test/index.js
+++ b/test/index.js
@@ -509,7 +509,7 @@ describe('env-var', function () {
     describe(':extraAccessors', function () {
       it('should add custom accessors to subsequent gotten values', function () {
         const fromMod = mod.from({ STRING: 'Hello, world!' }, {
-          asShout: function (raiseError, value) {
+          asShout: function (value) {
             return value.toUpperCase()
           }
         })
@@ -522,7 +522,7 @@ describe('env-var', function () {
 
       it('should allow overriding existing accessors', function () {
         const fromMod = mod.from({ STRING: 'Hello, world!' }, {
-          asString: function (raiseError, value) {
+          asString: function (value) {
             // https://stackoverflow.com/a/959004
             return value.split('').reverse().join('')
           }
@@ -533,7 +533,7 @@ describe('env-var', function () {
 
       it('should not attach accessors to other env instances', function () {
         const fromMod = mod.from({ STRING: 'Hello, world!' }, {
-          asNull: function (raiseError, value) {
+          asNull: function (value) {
             return null
           }
         })


### PR DESCRIPTION
**Note:** depends on #75 

closes #71

* Adds an optional `extraAccessors` param to `from()` that allows attaching a custom accessor to that instance.  Any variables subsequently gotten from that instance will have those custom accessors available.
  * Each instance has its own set of custom accessors.
  * It is allowed to override custom or even built-in accessors.

Example:
```
± % BOOTNODES="127.0.0.1, 192.168.1.1:8000" node
> const { from } = require('.')

> const env = from(process.env, {
... asNodes: (raiseError, value, type = Set) => {
.....   return new type(
.......     value.split(',')
.......       .map(s => s.trim())
.......       .map(s => s.split(':', 2))
.......       .map(([ip, port = 80]) => ({ ip, port }))
.......   )
..... }
... })

> const bootnodes = env.get('BOOTNODES').asNodes()

> bootnodes
Set {
  { ip: '127.0.0.1', port: 80 },
  { ip: '192.168.1.1', port: '8000' } }
```

See unit tests for additional examples.