### PR TITLE
[#74] Remove `raiseError` accessor param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,9 @@ and populate it with code following this structure:
 ```js
 /**
  * Validate that the environment value is an integer and equals zero.
- * @param {Function} raiseError use this to raise a cleanly formatted error
  * @param {String}   environmentValue this is the string from process.env
  */
-module.exports = function numberZero (raiseError, environmentValue) {
+module.exports = function numberZero (environmentValue) {
 
   // Your custom code should go here...below code is an example
 
@@ -333,7 +332,7 @@ module.exports = function numberZero (raiseError, environmentValue) {
   if (val === 0) {
     return ret;
   } else {
-    raiseError('should be zero')
+    throw new Error('should be zero')
   }
 }
 ```

--- a/lib/accessors/array.js
+++ b/lib/accessors/array.js
@@ -2,12 +2,12 @@
 
 const asString = require('./string')
 
-module.exports = function asArray (raiseError, value, delimiter) {
+module.exports = function asArray (value, delimiter) {
   delimiter = delimiter || ','
 
   if (!value.length) {
     return []
   } else {
-    return asString(raiseError, value).split(delimiter).filter(Boolean)
+    return asString(value).split(delimiter).filter(Boolean)
   }
 }

--- a/lib/accessors/bool-strict.js
+++ b/lib/accessors/bool-strict.js
@@ -1,10 +1,10 @@
 'use strict'
 
-module.exports = function asBoolStrict (raiseError, value) {
+module.exports = function asBoolStrict (value) {
   const val = value.toLowerCase()
 
   if ((val !== 'false') && (val !== 'true')) {
-    raiseError('should be either "true", "false", "TRUE", or "FALSE"')
+    throw new Error('should be either "true", "false", "TRUE", or "FALSE"')
   }
 
   return val !== 'false'

--- a/lib/accessors/bool.js
+++ b/lib/accessors/bool.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = function asBool (raiseError, value) {
+module.exports = function asBool (value) {
   const val = value.toLowerCase()
 
   const allowedValues = [
@@ -11,7 +11,7 @@ module.exports = function asBool (raiseError, value) {
   ]
 
   if (allowedValues.indexOf(val) === -1) {
-    raiseError('should be either "true", "false", "TRUE", "FALSE", 1, or 0')
+    throw new Error('should be either "true", "false", "TRUE", "FALSE", 1, or 0')
   }
 
   return !(((val === '0') || (val === 'false')))

--- a/lib/accessors/enum.js
+++ b/lib/accessors/enum.js
@@ -2,11 +2,11 @@
 
 const asString = require('./string')
 
-module.exports = function asEnum (raiseError, value, validValues) {
-  const valueString = asString(raiseError, value)
+module.exports = function asEnum (value, validValues) {
+  const valueString = asString(value)
 
   if (validValues.indexOf(valueString) < 0) {
-    raiseError(`should be a one of [${validValues.join(', ')}]`)
+    throw new Error(`should be one of [${validValues.join(', ')}]`)
   }
 
   return valueString

--- a/lib/accessors/float-negative.js
+++ b/lib/accessors/float-negative.js
@@ -2,11 +2,11 @@
 
 const asFloat = require('./float')
 
-module.exports = function floatNegative (raiseError, value) {
-  const ret = asFloat(raiseError, value)
+module.exports = function floatNegative (value) {
+  const ret = asFloat(value)
 
   if (ret > 0) {
-    raiseError('should be a negative float')
+    throw new Error('should be a negative float')
   }
 
   return ret

--- a/lib/accessors/float-positive.js
+++ b/lib/accessors/float-positive.js
@@ -2,11 +2,11 @@
 
 const asFloat = require('./float')
 
-module.exports = function floatPositive (raiseError, value) {
-  const ret = asFloat(raiseError, value)
+module.exports = function floatPositive (value) {
+  const ret = asFloat(value)
 
   if (ret < 0) {
-    raiseError('should be a positive float')
+    throw new Error('should be a positive float')
   }
 
   return ret

--- a/lib/accessors/float.js
+++ b/lib/accessors/float.js
@@ -1,10 +1,10 @@
 'use strict'
 
-module.exports = function asFloat (raiseError, value) {
+module.exports = function asFloat (value) {
   const n = parseFloat(value)
 
   if (isNaN(n)) {
-    raiseError('should be a valid float')
+    throw new Error('should be a valid float')
   }
 
   return n

--- a/lib/accessors/int-negative.js
+++ b/lib/accessors/int-negative.js
@@ -2,11 +2,11 @@
 
 const asInt = require('./int')
 
-module.exports = function intNegative (raiseError, value) {
-  const ret = asInt(raiseError, value)
+module.exports = function intNegative (value) {
+  const ret = asInt(value)
 
   if (ret > 0) {
-    raiseError('should be a negative integer')
+    throw new Error('should be a negative integer')
   }
 
   return ret

--- a/lib/accessors/int-positive.js
+++ b/lib/accessors/int-positive.js
@@ -2,11 +2,11 @@
 
 const asInt = require('./int')
 
-module.exports = function intPositive (raiseError, value) {
-  const ret = asInt(raiseError, value)
+module.exports = function intPositive (value) {
+  const ret = asInt(value)
 
   if (ret < 0) {
-    raiseError('should be a positive integer')
+    throw new Error('should be a positive integer')
   }
 
   return ret

--- a/lib/accessors/int.js
+++ b/lib/accessors/int.js
@@ -1,10 +1,10 @@
 'use strict'
 
-module.exports = function asInt (raiseError, value) {
+module.exports = function asInt (value) {
   const n = parseInt(value, 10)
 
   if (isNaN(n) || value.toString().indexOf('.') !== -1) {
-    raiseError('should be a valid integer')
+    throw new Error('should be a valid integer')
   }
 
   return n

--- a/lib/accessors/json-array.js
+++ b/lib/accessors/json-array.js
@@ -2,11 +2,11 @@
 
 const asJson = require('./json')
 
-module.exports = function asJsonArray (raiseError, value) {
-  var ret = asJson(raiseError, value)
+module.exports = function asJsonArray (value) {
+  var ret = asJson(value)
 
   if (!Array.isArray(ret)) {
-    raiseError('should be a parseable JSON Array')
+    throw new Error('should be a parseable JSON Array')
   }
 
   return ret

--- a/lib/accessors/json-object.js
+++ b/lib/accessors/json-object.js
@@ -2,11 +2,11 @@
 
 const asJson = require('./json')
 
-module.exports = function asJsonArray (raiseError, value) {
-  var ret = asJson(raiseError, value)
+module.exports = function asJsonArray (value) {
+  var ret = asJson(value)
 
   if (Array.isArray(ret)) {
-    raiseError('should be a parseable JSON Object')
+    throw new Error('should be a parseable JSON Object')
   }
 
   return ret

--- a/lib/accessors/json.js
+++ b/lib/accessors/json.js
@@ -1,9 +1,9 @@
 'use strict'
 
-module.exports = function asJson (raiseError, value) {
+module.exports = function asJson (value) {
   try {
     return JSON.parse(value)
   } catch (e) {
-    raiseError('should be valid (parseable) JSON')
+    throw new Error('should be valid (parseable) JSON')
   }
 }

--- a/lib/accessors/port.js
+++ b/lib/accessors/port.js
@@ -2,11 +2,11 @@
 
 const asIntPositive = require('./int-positive')
 
-module.exports = function asPortNumber (raiseError, value) {
-  var ret = asIntPositive(raiseError, value)
+module.exports = function asPortNumber (value) {
+  var ret = asIntPositive(value)
 
   if (ret > 65535) {
-    raiseError('cannot assign a port number greater than 65535')
+    throw new Error('cannot assign a port number greater than 65535')
   }
 
   return ret

--- a/lib/accessors/string.js
+++ b/lib/accessors/string.js
@@ -1,5 +1,5 @@
 'use strict'
 
-module.exports = function (raiseException, value) {
+module.exports = function (value) {
   return value
 }

--- a/lib/accessors/url-object.js
+++ b/lib/accessors/url-object.js
@@ -3,12 +3,12 @@
 const URL = require('url').URL
 const asString = require('./string')
 
-module.exports = function asUrlObject (raiseError, value) {
-  const ret = asString(raiseError, value)
+module.exports = function asUrlObject (value) {
+  const ret = asString(value)
 
   try {
     return new URL(ret)
   } catch (e) {
-    raiseError('should be a valid URL')
+    throw new Error('should be a valid URL')
   }
 }

--- a/lib/accessors/url-string.js
+++ b/lib/accessors/url-string.js
@@ -2,6 +2,6 @@
 
 const urlObject = require('./url-object')
 
-module.exports = function (raiseError, value) {
-  return urlObject(raiseError, value).toString()
+module.exports = function (value) {
+  return urlObject(value).toString()
 }

--- a/lib/env-error.js
+++ b/lib/env-error.js
@@ -3,7 +3,7 @@
 const inherits = require('util').inherits
 
 /**
- * Creates a cutom error class that can be used to identify errors generated
+ * Creates a custom error class that can be used to identify errors generated
  * by the module
  */
 function EnvVarError (message) {

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -12,13 +12,11 @@ module.exports = function getVariableAccessors (container, varName, defValue) {
   let isBase64 = false
 
   /**
-   * Generate a function to throw an error
+   * Throw an error with a consistent type/format.
    * @param {String} value
    */
-  function generateRaiseError (value) {
-    return function _raiseError (msg) {
-      throw new EnvVarError(`"${varName}" ${msg}, but was "${value}"`)
-    }
+  function raiseError (value, msg) {
+    throw new EnvVarError(`"${varName}" ${msg}, but was "${value}"`)
   }
 
   /**
@@ -43,7 +41,7 @@ module.exports = function getVariableAccessors (container, varName, defValue) {
 
       if (isBase64) {
         if (!value.match(base64Regex)) {
-          generateRaiseError(value)('should be a valid base64 string if using convertFromBase64')
+          raiseError(value, 'should be a valid base64 string if using convertFromBase64')
         }
 
         value = Buffer.from(value, 'base64').toString()
@@ -57,7 +55,7 @@ module.exports = function getVariableAccessors (container, varName, defValue) {
           args
         )
       } catch (error) {
-        generateRaiseError(value)(error.message)
+        raiseError(value, error.message)
       }
     }
   }

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -49,15 +49,16 @@ module.exports = function getVariableAccessors (container, varName, defValue) {
         value = Buffer.from(value, 'base64').toString()
       }
 
-      const args = [
-        generateRaiseError(value),
-        value
-      ].concat(Array.prototype.slice.call(arguments))
+      const args = [value].concat(Array.prototype.slice.call(arguments))
 
-      return accessor.apply(
-        accessor,
-        args
-      )
+      try {
+        return accessor.apply(
+          accessor,
+          args
+        )
+      } catch (error) {
+        generateRaiseError(value)(error.message)
+      }
     }
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -80,7 +80,7 @@ describe('env-var', function () {
     it('should throw when value is not expected', function () {
       expect(() => {
         expect(mod.get('ENUM').asEnum(['INVALID']))
-      }).to.throw('env-var: "ENUM" should be a one of [INVALID], but was "VALID"')
+      }).to.throw('env-var: "ENUM" should be one of [INVALID], but was "VALID"')
     })
   })
 


### PR DESCRIPTION
closes #74 

If an accessor cannot process an input value, it should just throw an exception instead.

There is a trade-off to this approach, in that the stacktrace for the accessor-thrown error is not preserved (replaced by `_raiseError()`), but accessors tend to be fairly simple in implementation, so it shouldn' be too difficult to locate the source of an error.