### PR TITLE
BREAKING CHANGE: change get() and required() function behaviours

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,5 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.md]
-trim_trailing_whitespace = false
-
 [*.py]
 indent_size = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 * Defer checks for `required()` until an accessor such as `asString()` is invoked.
 * Fix typings issue where `required()` was undefined on a `IPresentVariable`.
 
+Migration from 5.x to 6.0.0 should be smooth. Change any instance of
+`env.get(target, default)` to `env.get(target).default(default)`. For example:
+
+```js
+// Old 5.x code
+const emailAddr = env.get('EMAIL_ADDR', 'admin@example.com').asString()
+
+// New 6.x compatible code
+const emailAddr = env.get('EMAIL_ADDR').default('admin@example.com').asString()
+```
+
 ## 5.2.0 (22/11/19)
 * The `required()` function now verifies the variable is not an empty string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.0.0 (09/01/20)
+* Add support for setting an example value via the `example(string)` function.
+* Passing default values is now performed using the `default(string)` function.
+* Defer checks for `required()` until an accessor such as `asString()` is invoked.
+* Fix typings issue where `required()` was undefined on a `IPresentVariable`.
+
 ## 5.2.0 (22/11/19)
 * The `required()` function now verifies the variable is not an empty string
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016, 2019 Evan Shortiss
+Copyright (c) 2016, 2020 Evan Shortiss
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 Verification, sanitization, and type coercion for environment variables in
 Node.js. Particularly useful in TypeScript environments.
 
-* 🏋️‍♀️ Lightweight, at just 4.2kB when minified 🏋
-* 🔒 Helps prevent your program running in a misconfigured environment ✋
-* ⌨ TypeScript support provides compile time safety and better DevExp 🎉
-* 👨‍💻 Friendly error messages and example values improve DevExp 👩‍💻
+* 🏋 Lightweight, at just 4.2kB when minified
+* 🛑 Helps prevent your program running in a misconfigured environment
+* 🎉 TypeScript support provides compile time safety and better DevExp
+* 👩‍💻 Friendly error messages and example values improve DevExp
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 [![Known Vulnerabilities](https://snyk.io//test/github/evanshortiss/env-var/badge.svg?targetFile=package.json)](https://snyk.io//test/github/evanshortiss/env-var?targetFile=package.json)
 [![Greenkeeper badge](https://badges.greenkeeper.io/evanshortiss/env-var.svg)](https://greenkeeper.io/)
 
+Verification, sanitization, and type coercion for environment variables in
+Node.js. Supports TypeScript!
 </div>
 
-Verification, sanitization, and type coercion for environment variables in
-Node.js. Particularly useful in TypeScript environments.
 
 * 🏋 Lightweight, at just 4.2kB when minified
 * 🧹 Cleaner code, as [shown here](https://gist.github.com/evanshortiss/0cb049bf676b6138d13384671dad750d)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Verification, sanitization, and type coercion for environment variables in
 Node.js. Particularly useful in TypeScript environments.
 
 * 🏋 Lightweight, at just 4.2kB when minified
-* 🚫 Helps prevent your program running in a misconfigured environment
-* 🎉 TypeScript support provides compile time safety and better DevExp
-* 👩‍💻 Friendly error messages and example values improve DevExp
+* 🧹 Cleaner code, as [shown here](https://gist.github.com/evanshortiss/0cb049bf676b6138d13384671dad750d)
+* 🚫 [Fail fast](https://en.wikipedia.org/wiki/Fail-fast) if your environment is misconfigured
+* 👩‍💻 Friendly error messages and example values improve developer experience
+* 🎉 TypeScript support provides compile time safety and better developer experience
 
 
 ## Install
@@ -76,6 +77,9 @@ There is no tight coupling between [env-var](https://www.npmjs.com/package/env-v
 
 You can use `dotenv` with `env-var` via a `require()` calls in your code or
 preloading it with the `--require` or `-r` flag in the `node` CLI.
+
+Both examples below assume you have a `.env` file in your repository and it
+contains a line similar to `MY_VAR=a-string-value!`.
 
 ### Load dotenv via require()
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 Verification, sanitization, and type coercion for environment variables in
 Node.js. Particularly useful in TypeScript environments.
 
-* 📦 Just 4.2kB when minified.
-* 🔒 Helps prevent your program running in a misconfigured environment.
-* ⌨ TypeScript support provides compile time safety and better DevExp.
-* 📋 Friendly error messages and example values improve DevExp.
+* 🏋️‍♀️ Lightweight, at just 4.2kB when minified 🏋
+* 🔒 Helps prevent your program running in a misconfigured environment ✋
+* ⌨ TypeScript support provides compile time safety and better DevExp 🎉
+* 👨‍💻 Friendly error messages and example values improve DevExp 👩‍💻
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -525,9 +525,9 @@ env.get('ADMIN').asEmail()
 Contributions are welcomed. If you'd like to discuss an idea open an issue, or a
 PR with an initial implementation.
 
-If you want to add a new global accessor, it's easy. Add a file to
-`lib/accessors`, with the name of the type e.g add a file named `number-zero.js`
-into that folder and populate it with code following this structure:
+If you want to add a new global accessor add a file to `lib/accessors`, with
+the name of the type e.g add a file named `number-zero.js` into that folder
+and populate it with code following this structure:
 
 ```js
 /**

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 Verification, sanitization, and type coercion for environment variables in
 Node.js. Supports TypeScript!
 <br>
+<br>
 </div>
-
 
 * 🏋 Lightweight, at just 4.2kB when minified
 * 🧹 Cleaner code, as [shown here](https://gist.github.com/evanshortiss/0cb049bf676b6138d13384671dad750d)

--- a/README.md
+++ b/README.md
@@ -283,22 +283,17 @@ For example:
 ```js
 const env = require('env-var')
 
-const sampleConfig = JSON.stringify({
-  maxConnections: 10,
-  enableSsl: true
-})
-// Use POOL_SIZE if set, else use a value of 10
-const JSON_CONFIG = env.get('JSON_CONFIG')
+const ADMIN_EMAIL = env.get('ADMIN_EMAIL')
   .required()
-  .example(sampleConfig)
-  .asJsonObject()
+  .example('admin@example.com')
+  .asString()
 ```
 
-If *JSON_OBJECT* was not set this code would throw an error like so:
+If *ADMIN_EMAIL* was not set this code would throw an error like so:
 
 ```
-env-var: "JSON_CONFIG" is a required variable, but it was not set. An example
-of a valid value would be "{"maxConnections":10,"enableSsl":true}"
+env-var: "ADMIN_EMAIL" is a required variable, but it was not set. An example
+of a valid value would be "admin@example.com"
 ```
 
 #### default(string)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 Verification, sanitization, and type coercion for environment variables in
 Node.js. Supports TypeScript!
+<br>
 </div>
 
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ const env = require('env-var');
 const PASSWORD = env.get('DB_PASSWORD')
   // Throws an error if the DB_PASSWORD variable is not set (optional)
   .required()
-  // Convert DB_PASSWORD from base64 to a regular utf8 string (optional)
+  // Decode DB_PASSWORD from base64 to a utf8 string (optional)
   .convertFromBase64()
-  // Call asString (or other methods) to get the variable value (required)
+  // Call asString (or other APIs) to get the variable value (required)
   .asString();
 
-// Read in a port (checks that PORT is in the raneg 0 to 65535) or use a
-// default value of 5432 instead
+// Read in a port (checks that PORT is in the range 0 to 65535)
+// Alternatively, use amdefault value of 5432 if PORT is not defined
 const PORT = env.get('PORT').default('5432').asPortNumber()
 ```
 
@@ -65,16 +65,18 @@ const PORT = env.get('PORT').default('5432').asPortNumber()
 ```ts
 import * as env from 'env-var';
 
-// Read a PORT environment variable and ensure it's a positive number
-// An EnvVarError will be thrown if the variable is not set, or is not a number
+// Read a PORT environment variable and ensure it's a positive integer.
+// An EnvVarError will be thrown if the variable is not set, or if it
+// is not a positive integer.
 const PORT: number = env.get('PORT').required().asIntPositive();
 ```
 
 ## Usage with dotenv
 
 There is no tight coupling between [env-var](https://www.npmjs.com/package/env-var)
-[dotenv](https://www.npmjs.com/package/dotenv). This makes it easy to use
-`dotenv` in your preferred manner, and reduces package bloat too!
+[dotenv](https://www.npmjs.com/package/dotenv). Just `npm install dotenv` and
+use it whatever way you're used to. This loose coupling is a good thing since
+it reduces package bloat - only install what you need!
 
 You can use `dotenv` with `env-var` via a `require()` calls in your code or
 preloading it with the `--require` or `-r` flag in the `node` CLI.
@@ -111,20 +113,13 @@ const env = require('env-var')
 const myVar = env.get('MY_VAR').asString()
 ```
 
-## Benefits
-Fail fast if your environment is misconfigured. Also,
-[this code](https://gist.github.com/evanshortiss/75d936665a2a240fa1966770a85fb137) without
-`env-var` would require multiple `assert` calls, other logic, and be more
-complex to understand as [demonstrated here](https://gist.github.com/evanshortiss/0cb049bf676b6138d13384671dad750d).
-
 ## API
 
 ### Structure:
 
 * module (env-var)
-  * [EnvVarError()](#envvarerror)
   * [from()](#fromvalues-extraaccessors)
-  * [get()](#getvarname-default)
+  * [get()](#getvarname)
     * [variable](#variable)
       * [required()](#requiredisrequired--true)
       * [covertFromBase64()](#convertfrombase64)
@@ -147,34 +142,12 @@ complex to understand as [demonstrated here](https://gist.github.com/evanshortis
       * [asString()](#asstring)
       * [asUrlObject()](#asurlobject)
       * [asUrlString()](#asurlstring)
-
-### EnvVarError()
-This is the error class used to represent errors raised by this module. Sample
-usage:
-
-```js
-const env = require('env-var')
-let value = null
-
-try {
-  // will throw if you have not set this variable
-  value = env.get('MISSING_VARIABLE').required().asString()
-
-  // if catch error is set, we'll end up throwing here instead
-  throw new Error('some other error')
-} catch (e) {
-  if (e instanceof env.EnvVarError) {
-    console.log('we got an env-var error', e)
-  } else {
-    console.log('we got some error that wasn\'t an env-var error', e)
-  }
-}
-```
+  * [EnvVarError()](#envvarerror)
 
 ### from(values, extraAccessors)
 This function is useful if you're not in a typical Node.js environment, or for
 testing. It allows you to generate an env-var instance that reads from the
-given `values` instead of the default `process.env`.
+given `values` instead of the default `process.env` Object.
 
 ```js
 const env = require('env-var').from({
@@ -182,33 +155,36 @@ const env = require('env-var').from({
 })
 
 // apiUrl will be 'https://my.api.com/'
-const apiUrl = mockedEnv.get('API_BASE_URL').asUrlString()
+const apiUrl = env.get('API_BASE_URL').asUrlString()
 ```
 
 When calling `env.from()` you can also pass an optional parameter containing
-custom accessors that will be attached to any variables gotten by that
+custom accessors that will be attached to any variables returned by that
 env-var instance. This feature is explained in the
 [extraAccessors section](#extraAccessors) of these docs.
 
-### get([varname, [default]])
-You can call this function 3 different ways:
+### get(varname)
+This function has two behaviours:
+
+1. Calling with a string argument will make it read that value from the environment
+2. If no string argument is passed it will return the entire environment object
+
+Examples:
 
 ```js
 const env = require('env-var')
 
-// #1 - Return the requested variable (we're also checking it's a positive int)
-const limit = env.get('SOME_LIMIT').asIntPositive()
+// #1 - Read the requested variable and parse it to a positive integer
+const limit = env.get('MAX_CONNECTIONS').asIntPositive()
 
-// #2 - Return the requested variable, or use the given default if it isn't set
-const limit = env.get('SOME_LIMIT').default('10').asIntPositive()
-
-// #3 - Return the environment object (process.env by default - see env.from() docs for more)
-const allvars = env.get()
+// #2 - Returns the entire process.env object
+const allVars = env.get()
 ```
 
 ### variable
-A variable is returned by calling `env.get`. It has the exposes the following
-functions to validate and access the underlying value.
+A variable is returned by calling `env.get(varname)`. It exposes the following
+functions to validate and access the underlying value, set a default, or set
+an example value:
 
 #### example(string)
 Allows a developer to provide an example of a valid value for the environment
@@ -227,7 +203,8 @@ const ADMIN_EMAIL = env.get('ADMIN_EMAIL')
   .asString()
 ```
 
-If *ADMIN_EMAIL* was not set this code would throw an error like so:
+If *ADMIN_EMAIL* was not set this code would throw an error similar to that
+below to help a developer diagnose the issue:
 
 ```
 env-var: "ADMIN_EMAIL" is a required variable, but it was not set. An example
@@ -235,8 +212,10 @@ of a valid value would be "admin@example.com"
 ```
 
 #### default(string)
-Allows a default value to be provided for use if the value is not set in the
-environment.
+Allows a default value to be provided for use if the desired environment
+variable is not set in the program environment.
+
+Example:
 
 ```js
 const env = require('env-var')
@@ -246,13 +225,14 @@ const POOL_SIZE = env.get('POOL_SIZE').default('10').asIntPositive()
 ```
 
 #### required(isRequired = true)
-Ensure the variable is set on *process.env*. If the variable is not set or empty
-this function will throw an `EnvVarError`. If the variable is set it returns itself
-so you can access the underlying variable.
+Ensure the variable is set on *process.env*. If the variable is not set, or is
+set to an empty value, this function will cause an `EnvVarError` to be thrown
+when you attempt to read the value using `asString` or a similar function.
 
-Can be bypassed by passing `false`, i.e `required(false)`
+The `required()` check can be bypassed by passing `false`, i.e
+`required(false)`
 
-Full example:
+Example:
 
 ```js
 const env = require('env-var')
@@ -267,13 +247,11 @@ const PORT = env.get('PORT').required().asPortNumber()
 
 // If mode is production then this is required
 const SECRET = env.get('SECRET').required(NODE_ENV === 'production').asString()
-
-app.listen(PORT)
 ```
 
 #### convertFromBase64()
-Sometimes environment variables need to be encoded as base64. You can use this
-function to convert them to UTF-8 strings before parsing them.
+It's a common need to set an environment variable in base64 format. This
+function can be used to decode a base64 environment variable to UTF8.
 
 For example if we run the script script below, using the command `DB_PASSWORD=
 $(echo -n 'secret_password' | base64) node`, we'd get the following results:
@@ -286,7 +264,7 @@ const dbpass = env.get('DB_PASSWORD').convertFromBase64().asString()
 ```
 
 #### asPortNumber()
-Converts the value of the environment variable to a string and verifies it's
+Converts the value of the environment variable to an integer and verifies it's
 within the valid port range of 0-65535. As a result well known ports are
 considered valid by this function.
 
@@ -362,6 +340,29 @@ string. The validation is performed by passing the URL string to the
 Verifies that the variable is a valid URL string using the same method as
 `asUrlString()`, but instead returns the resulting URL instance. For details
 see the [Node.js URL docs](https://nodejs.org/docs/latest/api/url.html).
+
+### EnvVarError()
+This is the error class used to represent errors raised by this module. Sample
+usage:
+
+```js
+const env = require('env-var')
+let value = null
+
+try {
+  // will throw if you have not set this variable
+  value = env.get('MISSING_VARIABLE').required().asString()
+
+  // if catch error is set, we'll end up throwing here instead
+  throw new Error('some other error')
+} catch (e) {
+  if (e instanceof env.EnvVarError) {
+    console.log('we got an env-var error', e)
+  } else {
+    console.log('we got some error that wasn\'t an env-var error', e)
+  }
+}
+```
 
 ## Examples
 
@@ -573,3 +574,6 @@ env.get('SOME_NUMBER').asNumberZero()
 * @MikeyBurkman
 * @pepakriz
 * @rmblstrp
+* @shawnmclean
+* @todofixthis
+* @xuo

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
 Verification, sanitization, and type coercion for environment variables in
 Node.js. Particularly useful in TypeScript environments.
 
+* 📦 Just 4.2kB when minified.
+* 🔒 Helps prevent your program running in a misconfigured environment.
+* ⌨ TypeScript support provides compile time safety and better DevExp.
+* 📋 Friendly error messages and example values improve DevExp.
+
+
 ## Install
 **Note:** env-var requires Node version 8 or later.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,43 @@ import * as env from 'env-var';
 const PORT: number = env.get('PORT').required().asIntPositive();
 ```
 
+## Usage with dotenv
+
+There is no tight coupling between [env-var](https://www.npmjs.com/package/env-var)
+[dotenv](https://www.npmjs.com/package/dotenv). This makes it easy to use
+dotenv in your preferred manner, and reduces package bloat too.
+
+You can use dotenv via a `require()` calls in your code or preloading it via
+the `--require` or `-r` flag in the `node` CLI.
+
+### Load dotenv via require()
+
+This is per the default usage described by [dotenv's README](https://www.npmjs.com/package/dotenv#usage).
+
+```js
+// Read in the .env file
+require('dotenv').config()
+
+// Read the MY_VAR entry that dotenv created
+const env = require('env-var')
+const myVar = env.get('MY_VAR').asString()
+```
+
+### Preload dotenv via CLI Args
+
+This is per the [preload section](https://www.npmjs.com/package/dotenv#preload)
+of the dotenv README.
+
+```js
+// This is just a regular node script, but we started it using the command
+// "node -r dotenv/config your_script.js" via the terminal. This tells node
+// to load our variables using dotenv before running the rest of our script!
+
+// Read the MY_VAR entry that dotenv created
+const env = require('env-var')
+const myVar = env.get('MY_VAR').asString()
+```
+
 ## Benefits
 Fail fast if your environment is misconfigured. Also,
 [this code](https://gist.github.com/evanshortiss/75d936665a2a240fa1966770a85fb137) without

--- a/README.md
+++ b/README.md
@@ -180,121 +180,10 @@ const env = require('env-var').from({
 const apiUrl = mockedEnv.get('API_BASE_URL').asUrlString()
 ```
 
-#### extraAccessors
-When calling `from()` you can also pass an optional parameter containing
-additional accessors that will be attached to any variables gotten by that
-env-var instance.
-
-Accessor functions must accept at least one argument:
-
-- `{*} value`: The value that the accessor should process.
-
-**Important:** Do not assume that `value` is a string!
-
-Example:
-```js
-const { from } = require('env-var')
-
-// Environment variable that we will use for this example:
-process.env.ADMIN = 'admin@example.com'
-
-// Add an accessor named 'asEmail' that verifies that the value is a
-// valid-looking email address.
-const env = from(process.env, {
-  asEmail: (value) => {
-    const split = String(value).split('@')
-
-    // Validating email addresses is hard.
-    if (split.length !== 2) {
-      throw new Error('must contain exactly one "@"')
-    }
-
-    return value
-  }
-})
-
-// We specified 'asEmail' as the name for the accessor above, so now
-// we can call `asEmail()` like any other accessor.
-let validEmail = env.get('ADMIN').asEmail()
-```
-
-The accessor function may accept additional arguments if desired; these must be
-provided explicitly when the accessor is invoked.
-
-For example, we can modify the `asEmail()` accessor from above so that it
-optionally verifies the domain of the email address:
-```js
-const { from } = require('env-var')
-
-// Environment variable that we will use for this example:
-process.env.ADMIN = 'admin@example.com'
-
-// Add an accessor named 'asEmail' that verifies that the value is a
-// valid-looking email address.
-//
-// Note that the accessor function also accepts an optional second
-// parameter `requiredDomain` which can be provided when the accessor is
-// invoked (see below).
-const env = from(process.env, {
-  asEmail: (value, requiredDomain) => {
-    const split = String(value).split('@')
-
-    // Validating email addresses is hard.
-    if (split.length !== 2) {
-      throw new Error('must contain exactly one "@"')
-    }
-
-    if (requiredDomain && (split[1] !== requiredDomain)) {
-      throw new Error(`must end with @${requiredDomain}`)
-    }
-
-    return value
-  }
-})
-
-// We specified 'asEmail' as the name for the accessor above, so now
-// we can call `asEmail()` like any other accessor.
-//
-// `env-var` will provide the first argument for the accessor function
-// (`value`), but we declared a second argument `requiredDomain`, which
-// we can provide when we invoke the accessor.
-
-// Calling the accessor without additional parameters accepts an email
-// address with any domain.
-let validEmail = env.get('ADMIN').asEmail()
-
-// If we specify a parameter, then the email address must end with the
-// domain we specified.
-let invalidEmail = env.get('ADMIN').asEmail('github.com')
-```
-
-This feature is also available for TypeScript users. The `ExtensionFn` type is
-expoed to help in the creation of these new accessors.
-
-```ts
-import { from, ExtensionFn, EnvVarError } from 'env-var'
-
-// Environment variable that we will use for this example:
-process.env.ADMIN = 'admin@example.com'
-
-const asEmail: ExtensionFn<string> = (value) => {
-  const split = String(value).split('@')
-
-  // Validating email addresses is hard.
-  if (split.length !== 2) {
-    throw new Error('must contain exactly one "@"')
-  }
-
-  return value
-}
-
-const env = from(process.env, {
-  asEmail
-})
-
-// Returns the email string if it's valid, otherwise it will throw
-env.get('ADMIN').asEmail()
-```
+When calling `env.from()` you can also pass an optional parameter containing
+custom accessors that will be attached to any variables gotten by that
+env-var instance. This feature is explained in the
+[extraAccessors section](#extraAccessors) of these docs.
 
 ### get([varname, [default]])
 You can call this function 3 different ways:
@@ -508,6 +397,122 @@ const commaArray = env.get('DASH_ARRAY').asArray('-');
 
 // Returns the enum value if it's one of dev, test, or live
 const enumVal = env.get('ENVIRONMENT').asEnum(['dev', 'test', 'live'])
+```
+
+## extraAccessors
+When calling `from()` you can also pass an optional parameter containing
+additional accessors that will be attached to any variables gotten by that
+env-var instance.
+
+Accessor functions must accept at least one argument:
+
+- `{*} value`: The value that the accessor should process.
+
+**Important:** Do not assume that `value` is a string!
+
+Example:
+```js
+const { from } = require('env-var')
+
+// Environment variable that we will use for this example:
+process.env.ADMIN = 'admin@example.com'
+
+// Add an accessor named 'asEmail' that verifies that the value is a
+// valid-looking email address.
+const env = from(process.env, {
+  asEmail: (value) => {
+    const split = String(value).split('@')
+
+    // Validating email addresses is hard.
+    if (split.length !== 2) {
+      throw new Error('must contain exactly one "@"')
+    }
+
+    return value
+  }
+})
+
+// We specified 'asEmail' as the name for the accessor above, so now
+// we can call `asEmail()` like any other accessor.
+let validEmail = env.get('ADMIN').asEmail()
+```
+
+The accessor function may accept additional arguments if desired; these must be
+provided explicitly when the accessor is invoked.
+
+For example, we can modify the `asEmail()` accessor from above so that it
+optionally verifies the domain of the email address:
+```js
+const { from } = require('env-var')
+
+// Environment variable that we will use for this example:
+process.env.ADMIN = 'admin@example.com'
+
+// Add an accessor named 'asEmail' that verifies that the value is a
+// valid-looking email address.
+//
+// Note that the accessor function also accepts an optional second
+// parameter `requiredDomain` which can be provided when the accessor is
+// invoked (see below).
+const env = from(process.env, {
+  asEmail: (value, requiredDomain) => {
+    const split = String(value).split('@')
+
+    // Validating email addresses is hard.
+    if (split.length !== 2) {
+      throw new Error('must contain exactly one "@"')
+    }
+
+    if (requiredDomain && (split[1] !== requiredDomain)) {
+      throw new Error(`must end with @${requiredDomain}`)
+    }
+
+    return value
+  }
+})
+
+// We specified 'asEmail' as the name for the accessor above, so now
+// we can call `asEmail()` like any other accessor.
+//
+// `env-var` will provide the first argument for the accessor function
+// (`value`), but we declared a second argument `requiredDomain`, which
+// we can provide when we invoke the accessor.
+
+// Calling the accessor without additional parameters accepts an email
+// address with any domain.
+let validEmail = env.get('ADMIN').asEmail()
+
+// If we specify a parameter, then the email address must end with the
+// domain we specified.
+let invalidEmail = env.get('ADMIN').asEmail('github.com')
+```
+
+This feature is also available for TypeScript users. The `ExtensionFn` type is
+exposed to help in the creation of these new accessors.
+
+```ts
+import { from, ExtensionFn, EnvVarError } from 'env-var'
+
+// Environment variable that we will use for this example:
+process.env.ADMIN = 'admin@example.com'
+
+const asEmail: ExtensionFn<string> = (value) => {
+  const split = String(value).split('@')
+
+  // Validating email addresses is hard.
+  if (split.length !== 2) {
+    throw new Error('must contain exactly one "@"')
+  }
+
+  return value
+}
+
+const env = from(process.env, {
+  asEmail
+})
+
+// Returns the email string if it's valid, otherwise it will throw
+env.get('ADMIN').asEmail()
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Verification, sanitization, and type coercion for environment variables in
 Node.js. Particularly useful in TypeScript environments.
 
 * 🏋 Lightweight, at just 4.2kB when minified
-* 🛑 Helps prevent your program running in a misconfigured environment
+* 🚫 Helps prevent your program running in a misconfigured environment
 * 🎉 TypeScript support provides compile time safety and better DevExp
 * 👩‍💻 Friendly error messages and example values improve DevExp
 
@@ -72,10 +72,10 @@ const PORT: number = env.get('PORT').required().asIntPositive();
 
 There is no tight coupling between [env-var](https://www.npmjs.com/package/env-var)
 [dotenv](https://www.npmjs.com/package/dotenv). This makes it easy to use
-dotenv in your preferred manner, and reduces package bloat too.
+`dotenv` in your preferred manner, and reduces package bloat too!
 
-You can use dotenv via a `require()` calls in your code or preloading it via
-the `--require` or `-r` flag in the `node` CLI.
+You can use `dotenv` with `env-var` via a `require()` calls in your code or
+preloading it with the `--require` or `-r` flag in the `node` CLI.
 
 ### Load dotenv via require()
 
@@ -93,7 +93,8 @@ const myVar = env.get('MY_VAR').asString()
 ### Preload dotenv via CLI Args
 
 This is per the [preload section](https://www.npmjs.com/package/dotenv#preload)
-of the dotenv README.
+of the dotenv README. Run the following code by using the
+`node -r dotenv/config your_script.js` command.
 
 ```js
 // This is just a regular node script, but we started it using the command
@@ -122,8 +123,8 @@ complex to understand as [demonstrated here](https://gist.github.com/evanshortis
     * [variable](#variable)
       * [required()](#requiredisrequired--true)
       * [covertFromBase64()](#convertfrombase64)
-      * [example(string)](#example)
-      * [default(string)](#default)
+      * [example(string)](#examplestring)
+      * [default(string)](#defaultstring)
       * [asArray()](#asarraydelimiter-string)
       * [asBoolStrict()](#asboolstrict)
       * [asBool()](#asbool)
@@ -197,10 +198,10 @@ const { from } = require('env-var')
 // Environment variable that we will use for this example:
 process.env.ADMIN = 'admin@example.com'
 
-// Add an accessor named 'checkEmail' that verifies that the value is a
+// Add an accessor named 'asEmail' that verifies that the value is a
 // valid-looking email address.
 const env = from(process.env, {
-  checkEmail: (value) => {
+  asEmail: (value) => {
     const split = String(value).split('@')
 
     // Validating email addresses is hard.
@@ -212,15 +213,15 @@ const env = from(process.env, {
   }
 })
 
-// We specified 'checkEmail' as the name for the accessor above, so now
-// we can call `checkEmail()` like any other accessor.
-let validEmail = env.get('ADMIN').checkEmail()
+// We specified 'asEmail' as the name for the accessor above, so now
+// we can call `asEmail()` like any other accessor.
+let validEmail = env.get('ADMIN').asEmail()
 ```
 
 The accessor function may accept additional arguments if desired; these must be
 provided explicitly when the accessor is invoked.
 
-For example, we can modify the `checkEmail()` accessor from above so that it
+For example, we can modify the `asEmail()` accessor from above so that it
 optionally verifies the domain of the email address:
 ```js
 const { from } = require('env-var')
@@ -228,14 +229,14 @@ const { from } = require('env-var')
 // Environment variable that we will use for this example:
 process.env.ADMIN = 'admin@example.com'
 
-// Add an accessor named 'checkEmail' that verifies that the value is a
+// Add an accessor named 'asEmail' that verifies that the value is a
 // valid-looking email address.
 //
 // Note that the accessor function also accepts an optional second
 // parameter `requiredDomain` which can be provided when the accessor is
 // invoked (see below).
 const env = from(process.env, {
-  checkEmail: (value, requiredDomain) => {
+  asEmail: (value, requiredDomain) => {
     const split = String(value).split('@')
 
     // Validating email addresses is hard.
@@ -251,8 +252,8 @@ const env = from(process.env, {
   }
 })
 
-// We specified 'checkEmail' as the name for the accessor above, so now
-// we can call `checkEmail()` like any other accessor.
+// We specified 'asEmail' as the name for the accessor above, so now
+// we can call `asEmail()` like any other accessor.
 //
 // `env-var` will provide the first argument for the accessor function
 // (`value`), but we declared a second argument `requiredDomain`, which
@@ -260,11 +261,11 @@ const env = from(process.env, {
 
 // Calling the accessor without additional parameters accepts an email
 // address with any domain.
-let validEmail = env.get('ADMIN').checkEmail()
+let validEmail = env.get('ADMIN').asEmail()
 
 // If we specify a parameter, then the email address must end with the
 // domain we specified.
-let invalidEmail = env.get('ADMIN').checkEmail('github.com')
+let invalidEmail = env.get('ADMIN').asEmail('github.com')
 ```
 
 This feature is also available for TypeScript users. The `ExtensionFn` type is
@@ -276,7 +277,7 @@ import { from, ExtensionFn, EnvVarError } from 'env-var'
 // Environment variable that we will use for this example:
 process.env.ADMIN = 'admin@example.com'
 
-const checkEmail: ExtensionFn<string> = (value) => {
+const asEmail: ExtensionFn<string> = (value) => {
   const split = String(value).split('@')
 
   // Validating email addresses is hard.
@@ -288,11 +289,11 @@ const checkEmail: ExtensionFn<string> = (value) => {
 }
 
 const env = from(process.env, {
-  checkEmail
+  asEmail
 })
 
 // Returns the email string if it's valid, otherwise it will throw
-env.get('ADMIN').checkEmail()
+env.get('ADMIN').asEmail()
 ```
 
 ### get([varname, [default]])

--- a/env-var.d.ts
+++ b/env-var.d.ts
@@ -251,11 +251,6 @@ interface IEnv<PresentVariable, OptionalVariable> {
   get (varName: string): OptionalVariable;
 
   /**
-   * Gets an environment variable, using the default value if it is not already set
-   */
-  get (varName: string, defaultValue: string): PresentVariable;
-
-  /**
    * Returns a new env-var instance, where the given object is used for the environment variable mapping.
    * Use this when writing unit tests or in environments outside node.js.
    */
@@ -279,7 +274,6 @@ export type ExtensionFn<T> = (value: string, ...args: any[]) => T
 
 export function get(): {[varName: string]: string}
 export function get(varName: string): IOptionalVariable;
-export function get(varName: string, defaultValue: string): IPresentVariable;
 export function from<T extends Extensions, K extends keyof T>(values: NodeJS.ProcessEnv, extensions?: T): IEnv<
   IPresentVariable & Record<K, (...args: any[]) => ReturnType<T[K]>>,
   IOptionalVariable & Record<K, (...args: any[]) => ReturnType<T[K]>|undefined>

--- a/env-var.d.ts
+++ b/env-var.d.ts
@@ -10,6 +10,24 @@ interface IPresentVariable {
   convertFromBase64: () => IPresentVariable
 
   /**
+   * Provide an example value that can be used in error output if the variable
+   * is not set, or is set to an invalid value
+   */
+  example: (example: string) => IPresentVariable
+
+  /**
+   * Set a default value for this variable. This will be used if a value is not
+   * set in the process environment
+   */
+  default: (value: string) => IPresentVariable;
+
+  /**
+   * Ensures the variable is set on process.env. If it's not set an exception
+   * will be thrown. Can pass false to bypass the check.
+   */
+  required: (isRequired?: boolean) => IPresentVariable;
+
+  /**
    * Converts a number to an integer and verifies it's in port ranges 0-65535
    */
   asPortNumber: () => number
@@ -106,10 +124,22 @@ interface IOptionalVariable {
   /**
    * Converts a bas64 environment variable to ut8
    */
-  convertFromBase64: () => IOptionalVariable
+  convertFromBase64: () => IOptionalVariable;
 
   /**
-   * Ensures the variable is set on process.env, if not an exception will be thrown.
+   * Provide an example value that can be used in error output if the variable
+   * is not set, or is set to an invalid value
+   */
+  example: (value: string) => IOptionalVariable;
+
+  /**
+   * Set a default value for this variable. This will be used if a value is not
+   * set in the process environment
+   */
+  default: (value: string) => IPresentVariable;
+
+  /**
+   * Ensures the variable is set on process.env. If it's not set an exception will be thrown.
    * Can pass false to bypass the check
    */
   required: (isRequired?: boolean) => IPresentVariable;

--- a/env-var.js
+++ b/env-var.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const variable = require('./lib/variable')
+const EnvVarError = require('./lib/env-error')
 
 /**
  * Returns an "env-var" instance that reads from the given container of values.
@@ -25,9 +26,13 @@ const from = (container, extraAccessors) => {
      * @param  {String} variableName Name of the environment variable requested
      * @return {Object}
      */
-    get: (variableName) => {
+    get: function (variableName) {
       if (!variableName) {
         return container
+      }
+
+      if (arguments.length > 1) {
+        throw new EnvVarError('It looks like you passed more than one argument to env.get(). Since env-var@6.0.0 this is no longer supported. To set a default value use env.get(TARGET).default(DEFAULT)')
       }
 
       return variable(container, variableName, extraAccessors || {})

--- a/env-var.js
+++ b/env-var.js
@@ -23,15 +23,14 @@ const from = (container, extraAccessors) => {
     /**
      * Returns a variable instance with helper functions, or process.env
      * @param  {String} variableName Name of the environment variable requested
-     * @param  {String} defaultValue Optional default to use as the value
      * @return {Object}
      */
-    get: (variableName, defaultValue) => {
+    get: (variableName) => {
       if (!variableName) {
         return container
       }
 
-      return variable(container, variableName, defaultValue, extraAccessors || {})
+      return variable(container, variableName, extraAccessors || {})
     }
   }
 }

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -30,7 +30,7 @@ module.exports = function getVariableAccessors (container, varName, extraAccesso
     }
 
     if (example) {
-      errMsg = `${errMsg}. An example of a valid value would be "${example}"`
+      errMsg = `${errMsg}. An example of a valid value would be: ${example}`
     }
 
     throw new EnvVarError(errMsg)
@@ -127,11 +127,15 @@ module.exports = function getVariableAccessors (container, varName, extraAccesso
      * @param {String} value
      */
     default: function (value) {
-      if (typeof value !== 'string') {
-        throw new EnvVarError('values passed to default() must be of type string')
+      if (typeof value === 'number') {
+        defValue = value.toString()
+      } else if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+        defValue = JSON.stringify(value)
+      } else if (typeof value !== 'string') {
+        throw new EnvVarError('values passed to default() must be of Number, String, Array, or Object type')
+      } else {
+        defValue = value
       }
-
-      defValue = value
 
       return accessors
     },

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -12,15 +12,28 @@ const base64Regex = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-
  * @param  {Object} extraAccessors Extra accessors to install.
  * @return {Object}
  */
-module.exports = function getVariableAccessors (container, varName, defValue, extraAccessors) {
+module.exports = function getVariableAccessors (container, varName, extraAccessors) {
   let isBase64 = false
+  let isRequired = false
+  let defValue
+  let example
 
   /**
    * Throw an error with a consistent type/format.
    * @param {String} value
    */
   function raiseError (value, msg) {
-    throw new EnvVarError(`"${varName}" ${msg}, but was "${value}"`)
+    let errMsg = `"${varName}" ${msg}`
+
+    if (value) {
+      errMsg = `${errMsg}, but is set to "${value}"`
+    }
+
+    if (example) {
+      errMsg = `${errMsg}. An example of a valid value would be "${example}"`
+    }
+
+    throw new EnvVarError(errMsg)
   }
 
   /**
@@ -32,15 +45,23 @@ module.exports = function getVariableAccessors (container, varName, defValue, ex
       let value = container[varName]
 
       if (typeof value === 'undefined') {
-        if (typeof defValue === 'undefined') {
-          // Need to return since no value is available. If a value needed to
-          // be available required() should be called, or a default passed
-          return
+        if (typeof defValue === 'undefined' && isRequired) {
+          // Var is not set, nor is a default. Throw an error
+          raiseError(undefined, 'is a required variable, but it was not set')
+        } else if (defValue) {
+          value = defValue
+        } else {
+          // return undefined since variable is not required and
+          // there's no default value provided
+          return undefined
         }
+      }
 
-        // Assign the default as the value since process.env does not contain
-        // the desired variable
-        value = defValue
+      if (isRequired) {
+        // Need to verify that required variables aren't just whitespace
+        if (value.trim().length === 0) {
+          raiseError(undefined, 'is a required variable, but its value was empty')
+        }
       }
 
       if (isBase64) {
@@ -91,6 +112,10 @@ module.exports = function getVariableAccessors (container, varName, defValue, ex
     asUrlObject: generateAccessor(require('./accessors/url-object')),
     asUrlString: generateAccessor(require('./accessors/url-string')),
 
+    /**
+     * Instructs env-var to first convert the value of the variable from base64
+     * to utf when reading it using a function such as asString()
+     */
     convertFromBase64: function () {
       isBase64 = true
 
@@ -98,23 +123,43 @@ module.exports = function getVariableAccessors (container, varName, defValue, ex
     },
 
     /**
+     * Set a default value for the variable
+     * @param {String} value
+     */
+    default: function (value) {
+      if (typeof value !== 'string') {
+        throw new EnvVarError('values passed to default() must be of type string')
+      }
+
+      defValue = value
+
+      return accessors
+    },
+
+    /**
      * Ensures a variable is set in the given environment container. Throws an
      * EnvVarError if the variable is not set or a default is not provided
-     * @param {Boolean} isRequired
+     * @param {Boolean} required
      */
-    required: function (isRequired) {
-      if (isRequired === false) {
-        return accessors
+    required: function (required) {
+      if (typeof required === 'undefined') {
+        // If no value is passed assume that developer means "true"
+        // This is to retain support legacy usage (and intuitive)
+        isRequired = true
+      } else {
+        isRequired = required
       }
 
-      if (typeof container[varName] === 'undefined' && typeof defValue === 'undefined') {
-        throw new EnvVarError(`"${varName}" is a required variable, but it was not set`)
-      }
+      return accessors
+    },
 
-      const value = typeof container[varName] === 'undefined' ? defValue : container[varName]
-      if (value.trim().length === 0) {
-        throw new EnvVarError(`"${varName}" is a required variable, but its value was empty`)
-      }
+    /**
+     * Set an example value for this variable. If the variable value is not set
+     * or is set to an invalid value this example will be show in error output.
+     * @param {String} example
+     */
+    example: function (ex) {
+      example = ex
 
       return accessors
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "env-var",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "Verification, sanatization, and type coercion for environment variables in Node.js",
   "main": "env-var.js",
   "typings": "env-var.d.ts",

--- a/test/index.js
+++ b/test/index.js
@@ -52,7 +52,7 @@ describe('env-var', function () {
 
   describe('default values', function () {
     it('should return the default', function () {
-      const ret = mod.get('XXX_NOT_DEFINED', 'default').asString()
+      const ret = mod.get('XXX_NOT_DEFINED').default('default').asString()
 
       expect(ret).to.equal('default')
     })
@@ -69,7 +69,7 @@ describe('env-var', function () {
     it('should throw an error due to malformed base64', function () {
       expect(() => {
         mod.get('INVALID_BASE_64').convertFromBase64().asString()
-      }).throw(/"INVALID_BASE_64" should be a valid base64 string if using convertFromBase64, but was "a|GV-sb*G8="/g)
+      }).throw(/"INVALID_BASE_64" should be a valid base64 string if using convertFromBase64, but is set to "a|GV-sb*G8="/g)
     })
   })
 
@@ -82,7 +82,7 @@ describe('env-var', function () {
     it('should throw when value is not expected', function () {
       expect(() => {
         expect(mod.get('ENUM').asEnum(['INVALID']))
-      }).to.throw('env-var: "ENUM" should be one of [INVALID], but was "VALID"')
+      }).to.throw('env-var: "ENUM" should be one of [INVALID], but is set to "VALID"')
     })
   })
 
@@ -104,7 +104,7 @@ describe('env-var', function () {
 
       expect(() => {
         mod.get('URL').asUrlString()
-      }).to.throw('env-var: "URL" should be a valid URL, but was "not a url"')
+      }).to.throw('env-var: "URL" should be a valid URL, but is set to "not a url"')
     })
   })
 
@@ -118,7 +118,7 @@ describe('env-var', function () {
 
       expect(() => {
         mod.get('URL').asUrlObject()
-      }).to.throw('env-var: "URL" should be a valid URL, but was "not a url"')
+      }).to.throw('env-var: "URL" should be a valid URL, but is set to "not a url"')
     })
   })
 
@@ -387,12 +387,12 @@ describe('env-var', function () {
 
     it('should throw an exception when required, set, empty and empty default value', function () {
       expect(function () {
-        mod.get('EMPTY_STRING', '').required().asString()
+        mod.get('EMPTY_STRING').default('').required().asString()
       }).to.throw()
     })
 
     it('should not throw if required, set, empty but has a default value', function () {
-      expect(mod.get('XXX_NOT_DEFINED', 'default').required().asString()).to.equal('default')
+      expect(mod.get('XXX_NOT_DEFINED').default('default').required().asString()).to.equal('default')
     })
 
     it('should return undefined when not set and not required', function () {
@@ -478,20 +478,47 @@ describe('env-var', function () {
 
       expect(function () {
         mod.get('PORT_NUMBER').asPortNumber()
-      }).to.throw('should be a positive integer, but was "-2"')
+      }).to.throw('should be a positive integer, but is set to "-2"')
     })
     it('should raise an error for ports greater than 65535', function () {
       process.env.PORT_NUMBER = '700000'
 
       expect(function () {
         mod.get('PORT_NUMBER').asPortNumber()
-      }).to.throw('cannot assign a port number greater than 65535, but was "700000"')
+      }).to.throw('cannot assign a port number greater than 65535, but is set to "700000"')
     })
 
     it('should return a number for valid ports', function () {
       process.env.PORT_NUMBER = '8080'
 
       expect(mod.get('PORT_NUMBER').asPortNumber()).to.equal(8080)
+    })
+  })
+
+  describe('#example', () => {
+    let fromMod
+
+    beforeEach(() => {
+      fromMod = mod.from({
+        JSON_CONFIG: '{1,2]'
+      })
+    })
+
+    const sampleConfig = JSON.stringify({
+      maxConnections: 10,
+      enableSsl: true
+    })
+
+    it('should throw an error with a valid example message', () => {
+      expect(() => {
+        fromMod.get('JSON_CONFIG').example(sampleConfig).asJsonArray()
+      }).to.throw(`env-var: "JSON_CONFIG" should be valid (parseable) JSON, but is set to "{1,2]". An example of a valid value would be "${sampleConfig}"`)
+    })
+
+    it('should throw an error with a valid example message', () => {
+      expect(() => {
+        fromMod.get('MISSING_JSON_CONFIG').required().example('[1,2,3]').asJsonArray()
+      }).to.throw('env-var: "MISSING_JSON_CONFIG" is a required variable, but it was not set. An example of a valid value would be "[1,2,3]"')
     })
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,12 @@ describe('env-var', function () {
 
       expect(ret).to.equal('default')
     })
+
+    it('should throw an error if default is not passed as a string', () => {
+      expect(() => {
+        mod.get('MISSING_NO').default(42).asString()
+      }).to.throw('env-var: values passed to default() must be of type string')
+    })
   })
 
   describe('#convertFromBase64', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -50,6 +50,14 @@ describe('env-var', function () {
     })
   })
 
+  describe('#get(target, default) deprecation message', () => {
+    it('should throw an error if using pre 6.x syntax', () => {
+      expect(() => {
+        mod.get('SOMETHING', 'default somthing value').asString()
+      }).to.throw('env-var: It looks like you passed more than one argument to env.get(). Since env-var@6.0.0 this is no longer supported. To set a default value use env.get(TARGET).default(DEFAULT)')
+    })
+  })
+
   describe('default values', function () {
     it('should return the default', function () {
       const ret = mod.get('XXX_NOT_DEFINED').default('default').asString()

--- a/test/index.js
+++ b/test/index.js
@@ -57,10 +57,30 @@ describe('env-var', function () {
       expect(ret).to.equal('default')
     })
 
-    it('should throw an error if default is not passed as a string', () => {
+    it('should support passing a number type', () => {
+      expect(mod.get('MISSING_NO').default(42).asString()).to.equal('42')
+    })
+
+    it('should support passing a number type and returning as a number', () => {
+      expect(mod.get('MISSING_NO').default(42).asIntPositive()).to.equal(42)
+    })
+
+    it('should support passing objects', () => {
+      const tpl = {
+        name: 'ok'
+      }
+      expect(mod.get('MISSING_OBJECT').default(tpl).asJsonObject()).to.deep.equal(tpl)
+    })
+
+    it('should support passing arrays', () => {
+      const tpl = [1, 2, 3]
+      expect(mod.get('MISSING_ARRAY').default(tpl).asJsonArray()).to.deep.equal(tpl)
+    })
+
+    it('should error on null', () => {
       expect(() => {
-        mod.get('MISSING_NO').default(42).asString()
-      }).to.throw('env-var: values passed to default() must be of type string')
+        expect(mod.get('MISSING_NULL_DEFAULT').default(null).asJsonArray())
+      }).to.throw('env-var: values passed to default() must be of Number, String, Array, or Object type')
     })
   })
 
@@ -518,13 +538,13 @@ describe('env-var', function () {
     it('should throw an error with a valid example message', () => {
       expect(() => {
         fromMod.get('JSON_CONFIG').example(sampleConfig).asJsonArray()
-      }).to.throw(`env-var: "JSON_CONFIG" should be valid (parseable) JSON, but is set to "{1,2]". An example of a valid value would be "${sampleConfig}"`)
+      }).to.throw(`env-var: "JSON_CONFIG" should be valid (parseable) JSON, but is set to "{1,2]". An example of a valid value would be: ${sampleConfig}`)
     })
 
     it('should throw an error with a valid example message', () => {
       expect(() => {
         fromMod.get('MISSING_JSON_CONFIG').required().example('[1,2,3]').asJsonArray()
-      }).to.throw('env-var: "MISSING_JSON_CONFIG" is a required variable, but it was not set. An example of a valid value would be "[1,2,3]"')
+      }).to.throw('env-var: "MISSING_JSON_CONFIG" is a required variable, but it was not set. An example of a valid value would be: [1,2,3]')
     })
   })
 


### PR DESCRIPTION
6.x release preparation:

* Add support for setting an example value via the `example(string)` function.
* Passing default values is now performed using the `default(string)` function.
* Defer checks for `required()` until an accessor such as `asString()` is invoked.
* Fix typings issue where `required()` was undefined on a `IPresentVariable`.