### PR TITLE
Remove superseeded nodejs dependencies in order to allow browser usage

### DIFF
--- a/lib/accessors/url-object.js
+++ b/lib/accessors/url-object.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const URL = require('url').URL
 const asString = require('./string')
 
 module.exports = function asUrlObject (value) {

--- a/lib/env-error.js
+++ b/lib/env-error.js
@@ -1,17 +1,20 @@
 'use strict'
 
-const inherits = require('util').inherits
-
 /**
- * Creates a custom error class that can be used to identify errors generated
+ * Custom error class that can be used to identify errors generated
  * by the module
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error}
  */
-function EnvVarError (message) {
-  Error.captureStackTrace(this, this.constructor)
-  this.name = 'EnvVarError'
-  this.message = `env-var: ${message}`
-};
+class EnvVarError extends Error {
+  constructor (message, ...params) {
+    super(`env-var: ${message}`, ...params)
 
-inherits(EnvVarError, Error)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, EnvVarError)
+    }
+
+    this.name = 'EnvVarError'
+  }
+}
 
 module.exports = EnvVarError

--- a/lib/env-error.js
+++ b/lib/env-error.js
@@ -8,7 +8,7 @@
 class EnvVarError extends Error {
   constructor (message, ...params) {
     super(`env-var: ${message}`, ...params)
-
+/* istanbul ignore else */
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, EnvVarError)
     }


### PR DESCRIPTION
I would like to use env-var with react and react-native projects. Env-var should otherwise work but it has two nodejs specific dependencies which seem to have been superseeded with browser compatible ones.

1. util inherits usage is discouraged and regular [es6 class inheritance](https://nodejs.org/docs/latest-v8.x/api/util.html#util_util_inherits_constructor_superconstructor)  is preferred
2. nodejs URL is superseeded by the browser compatible [whatwg url api](https://nodejs.org/docs/latest-v8.x/api/url.html#url_the_whatwg_url_api)

There is slight change with the custom error to get full browser support. The captureStackTrace method is only available in v8 engines so have to if it like in the [mozdev example](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)

This causes issue with 100% test coverage requirement as the non-v8 branch is not tested and I have no idea how to mock Error without the captureStackTrace method. So this is something which would need fixing before merging.

