### PR TITLE
Number accessors

### DIFF
--- a/lib/accessors/float.js
+++ b/lib/accessors/float.js
@@ -3,7 +3,7 @@
 module.exports = function asFloat (value) {
   const n = parseFloat(value)
 
-  if (isNaN(n)) {
+  if (isNaN(n) || n.toString() !== value) {
     throw new Error('should be a valid float')
   }
 

--- a/lib/accessors/int.js
+++ b/lib/accessors/int.js
@@ -3,7 +3,7 @@
 module.exports = function asInt (value) {
   const n = parseInt(value, 10)
 
-  if (isNaN(n) || value.toString().indexOf('.') !== -1) {
+  if (isNaN(n) || n.toString(10) !== value) {
     throw new Error('should be a valid integer')
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -183,6 +183,14 @@ describe('env-var', function () {
         mod.get('INTEGER').asInt()
       }).to.throw()
     })
+
+    it('should throw an exception - non integer type found', function () {
+      process.env.INTEGER = '123nope'
+
+      expect(function () {
+        mod.get('INTEGER').asInt()
+      }).to.throw()
+    })
   })
 
   describe('#asIntPositive', function () {
@@ -222,6 +230,14 @@ describe('env-var', function () {
 
     it('should throw an exception - non float found', function () {
       process.env.FLOAT = 'nope'
+
+      expect(function () {
+        mod.get('FLOAT').asFloat()
+      }).to.throw()
+    })
+
+    it('should throw an exception - non float found', function () {
+      process.env.FLOAT = '192.168.1.1'
 
       expect(function () {
         mod.get('FLOAT').asFloat()


### PR DESCRIPTION
The number accessors are too permissive.
The `parseInt` and `parseFloat` functions allow strings beginning with numbers.

The solution here is to check if the parsed value is stringify, it should be the same as the input value.
