### PR TITLE
fix: remove duplicate identifier for EnvVarError

### DIFF
--- a/env-var.d.ts
+++ b/env-var.d.ts
@@ -305,7 +305,6 @@ export type RaiseErrorFn = (error: string) => void
 export type ExtensionFn<T> = (value: string, ...args: any[]) => T
 
 export const accessors: PublicAccessors
-export const EnvVarError: EnvVarError
 
 export function logger (varname: string, str: string): void
 


### PR DESCRIPTION
#150 to avoid ts error. `EnvVarError` class is exported on line 263

```
../../env-var/env-var.d.ts:263:14 - error TS2300: Duplicate identifier 'EnvVarError'.

263 export class EnvVarError extends Error {}
                 ~~~~~~~~~~~

../../env-var/env-var.d.ts:308:14 - error TS2300: Duplicate identifier 'EnvVarError'.

308 export const EnvVarError: EnvVarError
                 ~~~~~~~~~~~


Found 2 errors.
```

