### PR TITLE
implemented an accessser of #asEmailString()

### DIFF
--- a/lib/accessors/email-string.js
+++ b/lib/accessors/email-string.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const asString = require('./string')
+
+// eslint-disable-next-line no-control-regex
+const EMAIL_REGEX = /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\u0001-\u0008\u000b\u000c\u000e-\u001f\u0021\u0023-\u005b\u005d-\u007f]|\\[\u0001-\u0009\u000b\u000c\u000e-\u007f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\u0001-\u0008\u000b\u000c\u000e-\u001f\u0021-\u005a\u0053-\u007f]|\\[\u0001-\u0009\u000b\u000c\u000e-\u007f])+)\])$/
+
+module.exports = function asEmailString (value) {
+  const strValue = asString(value)
+
+  if (!EMAIL_REGEX.test(strValue)) {
+    throw new Error('should be a valid email address')
+  }
+
+  return strValue
+}

--- a/lib/accessors/index.js
+++ b/lib/accessors/index.js
@@ -24,5 +24,7 @@ module.exports = {
   asString: require('./string'),
 
   asUrlObject: require('./url-object'),
-  asUrlString: require('./url-string')
+  asUrlString: require('./url-string'),
+
+  asEmailString: require('./email-string')
 }

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,7 @@ describe('env-var', function () {
     ARRAY_WITH_DELIMITER_PREFIX: ',value',
     DASH_ARRAY: '1-2-3',
     URL: 'http://google.com/',
+    EMAIL: 'email@example.com',
     ENUM: 'VALID',
     EMPTY_STRING: '',
     EMPTY_STRING_WITH_WHITESPACE: '  '
@@ -581,6 +582,21 @@ describe('env-var', function () {
       process.env.REG_EXP = '^valid$'
 
       expect(mod.get('REG_EXP').asRegExp('i').flags).to.equal('i')
+    })
+  })
+
+  describe('#asEmailString', function () {
+    it('should return an email address', function () {
+      expect(mod.get('EMAIL').asEmailString()).to.be.a('string')
+      expect(mod.get('EMAIL').asEmailString()).to.equal(TEST_VARS.EMAIL)
+    })
+
+    it('should throw due to a bad email address', function () {
+      process.env.EMAIL = '.invalid@example.com'
+
+      expect(() => {
+        mod.get('EMAIL').asEmailString()
+      }).to.throw('env-var: "EMAIL" should be a valid email address')
     })
   })
 


### PR DESCRIPTION
# ISSUE
https://github.com/evanshortiss/env-var/issues/146


# Description
Basically I followed this [StackOverflow post](https://stackoverflow.com/questions/201323/how-can-i-validate-an-email-address-using-a-regular-expression), but replaced expressions of unicodes of '\xhh'  with '\uhhhh' because they are not standard in EcmaScript.
refs) https://stackoverflow.com/questions/29028756/javascript-unicode-regex-range-out-of-order-in-character-class
