### PR TITLE
Add missing type of `asEmailString()` according to PR #158

### DIFF
--- a/env-var.d.ts
+++ b/env-var.d.ts
@@ -153,6 +153,11 @@ interface VariableAccessors <AlternateType = unknown> {
   asString: () => AlternateType extends undefined ? undefined|string : string;
 
   /**
+   * Return the variable value as an Email. Throws an exception if value is not an Email.
+   */
+  asEmailString: () => AlternateType extends undefined ? undefined|string : string;
+
+  /**
    * Attempt to parse the variable to a JSON Object or Array. Throws an exception if parsing fails.
    */
   asJson: () => AlternateType extends undefined ? undefined|Object|Array<any> : Object|Array<any>;

--- a/env-var.d.ts
+++ b/env-var.d.ts
@@ -48,6 +48,11 @@ type PublicAccessors = {
   asString: (input: string) =>  string;
 
   /**
+   * Return the variable value as an Email. Throws an exception if value is not an Email.
+   */
+  asEmailString: (input: string) =>  string;
+
+  /**
    * Attempt to parse the variable to a JSON Object or Array. Throws an exception if parsing fails.
    */
   asJson: (input: string) => Object|Array<any>;


### PR DESCRIPTION
Hi @evanshortiss, I realize that the type of `asEmailString()` is missing, I put some changes