### PR TITLE
Fix 1.0 not recognized as float

### DIFF
--- a/lib/accessors/float.js
+++ b/lib/accessors/float.js
@@ -3,6 +3,8 @@
 module.exports = function asFloat (value) {
   const n = parseFloat(value)
 
+  // Some values are parsed as valid floats despite being obviously invalid, e.g. "1.o" or "192.168.1.1".
+  // In these cases we would want to throw an error.
   if (isNaN(n) || isNaN(value)) {
     throw new Error('should be a valid float')
   }

--- a/lib/accessors/float.js
+++ b/lib/accessors/float.js
@@ -3,7 +3,7 @@
 module.exports = function asFloat (value) {
   const n = parseFloat(value)
 
-  if (isNaN(n) || n.toString() !== value) {
+  if (isNaN(n) || isNaN(value)) {
     throw new Error('should be a valid float')
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -232,6 +232,14 @@ describe('env-var', function () {
     })
 
     it('should throw an exception - non float found', function () {
+      process.env.FLOAT = '1.o'
+
+      expect(function () {
+        mod.get('FLOAT').asFloat()
+      }).to.throw()
+    })
+
+    it('should throw an exception - non float found', function () {
       process.env.FLOAT = 'nope'
 
       expect(function () {

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ describe('env-var', function () {
     INVALID_BASE_64: 'a|GV-sb*G8=',
     STRING: 'oh hai',
     FLOAT: '12.43',
+    FLOAT_INTEGER: '1.0',
     INTEGER: '5',
     BOOL: 'false',
     JSON: '{"name":"value"}',
@@ -227,6 +228,7 @@ describe('env-var', function () {
     it('should return a float', function () {
       expect(mod.get('FLOAT').asFloat()).to.be.a('number')
       expect(mod.get('FLOAT').asFloat()).to.equal(parseFloat(TEST_VARS.FLOAT))
+      expect(mod.get('FLOAT_INTEGER').asFloat()).to.equal(parseFloat(TEST_VARS.FLOAT_INTEGER))
     })
 
     it('should throw an exception - non float found', function () {


### PR DESCRIPTION
This bug fix allows any floating number to be recognized as a true floating number. Before, `1.0` was parsed into `1` and an error was raised.