### PR TITLE
docs: update TS docstrings for positive/negative int/float validators

### DIFF
--- a/env-var.d.ts
+++ b/env-var.d.ts
@@ -16,12 +16,12 @@ type PublicAccessors = {
   asFloat: (input: string) => number;
 
   /**
-   * Performs the same task as asFloat(), but also verifies that the number is positive (greater than zero).
+   * Performs the same task as asFloat(), but also verifies that the number is positive (greater than or equal to zero).
    */
   asFloatPositive: (input: string) =>  number;
 
   /**
-   * Performs the same task as asFloat(), but also verifies that the number is negative (less than zero).
+   * Performs the same task as asFloat(), but also verifies that the number is negative (less than or equal to zero).
    */
   asFloatNegative: (input: string) => number;
 
@@ -32,12 +32,12 @@ type PublicAccessors = {
   asInt: (input: string) => number;
 
   /**
-   * Performs the same task as asInt(), but also verifies that the number is positive (greater than zero).
+   * Performs the same task as asInt(), but also verifies that the number is positive (greater than or equal to zero).
    */
   asIntPositive: (input: string) => number;
 
   /**
-   * Performs the same task as asInt(), but also verifies that the number is negative (less than zero).
+   * Performs the same task as asInt(), but also verifies that the number is negative (less than or equal to zero).
    */
   asIntNegative: (input: string) => number;
 
@@ -121,12 +121,12 @@ interface VariableAccessors <AlternateType = unknown> {
   asFloat: () => AlternateType extends undefined ? undefined|number : number;
 
   /**
-   * Performs the same task as asFloat(), but also verifies that the number is positive (greater than zero).
+   * Performs the same task as asFloat(), but also verifies that the number is positive (greater than or equal to zero).
    */
   asFloatPositive: () => AlternateType extends undefined ? undefined|number : number;
 
   /**
-   * Performs the same task as asFloat(), but also verifies that the number is negative (less than zero).
+   * Performs the same task as asFloat(), but also verifies that the number is negative (less than or equal to zero).
    */
   asFloatNegative: () => AlternateType extends undefined ? undefined|number : number;
 
@@ -137,12 +137,12 @@ interface VariableAccessors <AlternateType = unknown> {
   asInt: () => AlternateType extends undefined ? undefined|number : number;
 
   /**
-   * Performs the same task as asInt(), but also verifies that the number is positive (greater than zero).
+   * Performs the same task as asInt(), but also verifies that the number is positive (greater than or equal to zero).
    */
   asIntPositive: () => AlternateType extends undefined ? undefined|number : number;
 
   /**
-   * Performs the same task as asInt(), but also verifies that the number is negative (less than zero).
+   * Performs the same task as asInt(), but also verifies that the number is negative (less than or equal to zero).
    */
   asIntNegative: () => AlternateType extends undefined ? undefined|number : number;
 


### PR DESCRIPTION
Fixes [the same issue](https://github.com/evanshortiss/env-var/issues/103) that was already fixed by https://github.com/evanshortiss/env-var/pull/104 but for the TS docstrings.